### PR TITLE
Add modular MUA tool component

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import { probit, erf } from 'simple-statistics';
 import Latex from 'react-latex-next';
 import 'katex/dist/katex.min.css';
 import './App.css';
+import MuaTool from './components/MuaTool';
 
 // --- HELPER FUNCTIONS ---
 function bivariateNormalCDF(x, y, rho) {
@@ -1411,8 +1412,9 @@ function App() {
                         )}
                     </main>
                 </div>
-                
+
             </div>
+            <MuaTool />
         </div>
     );
 }

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders uncertainty analysis heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/Uncertainty Analysis/i);
+  expect(heading).toBeInTheDocument();
 });

--- a/src/components/MuaTool.css
+++ b/src/components/MuaTool.css
@@ -1,0 +1,58 @@
+.mua-tool {
+  margin-top: 2rem;
+  padding: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: #fafafa;
+}
+
+.mua-tool h2 {
+  margin-top: 0;
+}
+
+.mua-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.mua-table th,
+.mua-table td {
+  border: 1px solid #ddd;
+  padding: 0.5rem;
+  text-align: left;
+}
+
+.mua-table input {
+  width: 100%;
+  padding: 0.25rem;
+  box-sizing: border-box;
+}
+
+.add-btn {
+  margin-top: 0.5rem;
+  padding: 0.5rem 1rem;
+  background: #007bff;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.add-btn:hover {
+  background: #0056b3;
+}
+
+.remove-btn {
+  background: transparent;
+  border: none;
+  font-size: 1.25rem;
+  cursor: pointer;
+}
+
+.results {
+  margin-top: 1rem;
+}
+
+.results p {
+  margin: 0.25rem 0;
+}

--- a/src/components/MuaTool.js
+++ b/src/components/MuaTool.js
@@ -1,0 +1,86 @@
+import React, { useState } from 'react';
+import './MuaTool.css';
+
+/**
+ * MuaTool provides a simple interface for combining uncertainty
+ * contributors using the root-sum-of-squares method. Users can
+ * add or remove contributors and view the combined and expanded
+ * uncertainty.
+ */
+export default function MuaTool() {
+  const [contributors, setContributors] = useState([
+    { id: Date.now(), name: '', std: '' }
+  ]);
+
+  const addContributor = () => {
+    setContributors([...contributors, { id: Date.now(), name: '', std: '' }]);
+  };
+
+  const removeContributor = (id) => {
+    setContributors(contributors.filter(c => c.id !== id));
+  };
+
+  const updateContributor = (id, field, value) => {
+    setContributors(contributors.map(c => (
+      c.id === id ? { ...c, [field]: value } : c
+    )));
+  };
+
+  const combined = Math.sqrt(
+    contributors.reduce((sum, c) => sum + Math.pow(parseFloat(c.std) || 0, 2), 0)
+  );
+  const expanded = combined * 2; // default coverage factor k=2
+
+  return (
+    <div className="mua-tool">
+      <h2>Measurement Uncertainty Assistant</h2>
+      <table className="mua-table">
+        <thead>
+          <tr>
+            <th>Contributor</th>
+            <th>Std. Uncertainty</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {contributors.map(c => (
+            <tr key={c.id}>
+              <td>
+                <input
+                  type="text"
+                  value={c.name}
+                  onChange={e => updateContributor(c.id, 'name', e.target.value)}
+                  placeholder="e.g. Reference"
+                />
+              </td>
+              <td>
+                <input
+                  type="number"
+                  step="any"
+                  value={c.std}
+                  onChange={e => updateContributor(c.id, 'std', e.target.value)}
+                  placeholder="0.0"
+                />
+              </td>
+              <td>
+                <button
+                  className="remove-btn"
+                  onClick={() => removeContributor(c.id)}
+                  aria-label="remove contributor"
+                >
+                  ×
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <button className="add-btn" onClick={addContributor}>Add Contributor</button>
+      <div className="results">
+        <p><strong>Combined Standard Uncertainty:</strong> {combined.toFixed(4)}</p>
+        <p><strong>Expanded Uncertainty (k=2):</strong> {expanded.toFixed(4)}</p>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add standalone Measurement Uncertainty Assistant component
- integrate MUA tool into main app and update tests

## Testing
- `npm install --legacy-peer-deps --silent` *(failed: react-scripts 403 Forbidden)*
- `npm test --silent` *(failed: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689794ca6a988333a6f111fc63fcc39b