### PR TITLE
refactor: use MuaToolPro in DocumentPage

### DIFF
--- a/src/pages/DocumentPage.js
+++ b/src/pages/DocumentPage.js
@@ -3,7 +3,7 @@ import { probit, erf } from 'simple-statistics';
 import Latex from 'react-latex-next';
 import 'katex/dist/katex.min.css';
 import '../App.css';
-import MuaTool from '../components/MuaTool';
+import MuaToolPro from '../MuaToolPro';
 
 // --- HELPER FUNCTIONS ---
 function bivariateNormalCDF(x, y, rho) {
@@ -1414,7 +1414,7 @@ function DocumentPage() {
                 </div>
 
             </div>
-            <MuaTool />
+            <MuaToolPro />
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- refactor DocumentPage to use the new `MuaToolPro` component

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897c186acec8333b41e66fa403be610